### PR TITLE
Test: matched routes cannot resolve once superseded

### DIFF
--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -334,6 +334,39 @@ o.spec("route", function() {
 					})
 				})
 
+				o("route match supersedes a pending onmatch", function(done) {
+					var pending = false
+					var superseded = false
+
+					$window.location.href = prefix + "/"
+					route(root, "/a", {
+						"/a" : {
+							onmatch: function() {
+								pending = true
+							}
+						},
+						"/b" : {
+							render: function(){
+								superseded = true
+							}
+						}
+					})
+
+					callAsync(function() {
+						o(pending).equals(true)
+
+						route.set("/b")
+
+						redraw.publish()
+
+						setTimeout(function() {
+							o(superseded).equals(true)
+
+							done()
+						}, FRAME_BUDGET)
+					})
+				})
+
 				o("RouteResolver without `onmatch` hook calls `render` appropriately", function(done) {
 					var renderCount = 0
 					var Component = {

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -334,33 +334,36 @@ o.spec("route", function() {
 					})
 				})
 
-				o("route match supersedes a pending onmatch", function(done) {
-					var pending = false
-					var superseded = false
+				o("matched routes cannot resolve once superseded", function(done) {
+					var resolveA = undefined
+					var resolved = false
+					var Component = {
+						view: function() {
+							resolved = true
+
+							return m("div")
+						}
+					}
 
 					$window.location.href = prefix + "/"
 					route(root, "/a", {
 						"/a" : {
-							onmatch: function() {
-								pending = true
+							onmatch: function(resolve) {
+								resolveA = resolve
 							}
 						},
 						"/b" : {
-							render: function(){
-								superseded = true
+							onmatch: function() {
+								resolveA(Component)
 							}
 						}
 					})
 
 					callAsync(function() {
-						o(pending).equals(true)
-
 						route.set("/b")
 
-						redraw.publish()
-
 						setTimeout(function() {
-							o(superseded).equals(true)
+							o(resolved).equals(false)
 
 							done()
 						}, FRAME_BUDGET)


### PR DESCRIPTION
In this contrived simulation of a race conflict, route A is matched but doesn't resolve. The route is then set to B, and during B's onmatch window, route A attempts (and fails) to resolve.
